### PR TITLE
CL-PPCRE:SPLIT does not like NIL values for :END

### DIFF
--- a/client.lisp
+++ b/client.lisp
@@ -214,7 +214,7 @@ Thing can be a SERVER, STRING, or SYMBOL."
   (with-reconnect-handler server
     (flet ((prepare-arguments (arguments)
              (let ((final-arg (search " :" arguments)))
-               (append (cl-ppcre:split " +" arguments :end final-arg)
+               (append (cl-ppcre:split " +" arguments :end (or final-arg (length arguments)))
                        (when final-arg (list (subseq arguments (+ 2 final-arg))))))))
       (let ((name (name server)))
         (with-simple-restart (exit "<~a> Exit the receive loop." name)


### PR DESCRIPTION
When connecting to freenode, a RPL_MYINFO (004) message from IRC made
the function SPLIT signal an error, due to FINAL-ARG being NIL.
